### PR TITLE
Fix no-schedule course deletion bug

### DIFF
--- a/app/src/main/java/com/base12innovations/android/fireroad/models/doc/RoadDocument.java
+++ b/app/src/main/java/com/base12innovations/android/fireroad/models/doc/RoadDocument.java
@@ -346,9 +346,9 @@ public class RoadDocument extends Document {
 
     public List<Course> coursesForSemester(int semester) {
         if (courses.containsKey(semester)) {
-            return courses.get(semester);
+            return new ArrayList<>(courses.get(semester));
         }
-        return new ArrayList<Course>();
+        return new ArrayList<>();
     }
 
     public boolean addCourse(Course course, int semester) {


### PR DESCRIPTION
Resolves #10 

Courses were being deleted from the road if they were added to a schedule but did not have schedule information available. This is because `RoadDocument` was returning the actual list from its internal storage instead of copying it. Fixed by returning a copy from `coursesForSemester`.